### PR TITLE
More time for final wrap-up

### DIFF
--- a/agenda.md
+++ b/agenda.md
@@ -27,6 +27,6 @@ Time  | Description
 10:45 am | Breakout discussions
 12:00 pm | Break for lunch
 1:30 pm  | Breakout group discussions
-3:00 pm  | Breakout group presentations
+2:30 pm  | Breakout group presentations
 3:30 pm  | Planning (report/paper writing, next steps)
 4:00 pm  | Closing


### PR DESCRIPTION
Given that yesterday ran over, largely because the breakout groups reporting back to the whole room inspires further discussion by the whole room, I expect the same would happen today. I suggest we allow more time for this part of the day?  I think time spent at the end of the day consolidating thoughts, clarifying actions, etc. is valuable, or it'll all be upon the report authors.